### PR TITLE
Fixed: /etc/localtime and /etc/timezone should updated at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Locale
+
+## Available Options:
+```python
+nodes['foobar'] = {
+    'metadata': {
+        'locales': {
+            'used': [
+                'en_US.UTF-8 UTF-8',
+                'de_DE.UTF-8 UTF-8',
+            ],
+            'timezone': 'Europe/Berlin',
+        }
+    }
+}
+```

--- a/items.py
+++ b/items.py
@@ -528,7 +528,7 @@ files = {
         'mode': "0644"
     },
     "/etc/timezone": {
-        'content': "Europe/Berlin\n",
+        'content': "{}\n".format(node.metadata.get('locales', {}).get('timezone', 'Europe/Berlin')),
         'owner': "root",
         'group': "root",
         'mode': "0644"
@@ -541,5 +541,13 @@ files = {
         'triggers': {
             'action:regenerate_locale',
         }
+    }
+}
+
+symlinks = {
+    "/etc/localtime": {
+        'target': "/usr/share/zoneinfo/{}".format(node.metadata.get('locales', {}).get('timezone', 'Europe/Berlin')),
+        'owner': 'root',
+        'group': 'root',
     }
 }


### PR DESCRIPTION
Some programs used /etc/localtime.

``timedatectl`` also updates /etc/localtime, so we should do it too. ;)